### PR TITLE
[Feat/delete#4] 레이블 삭제 API 구현

### DIFF
--- a/server/controllers/api/label.js
+++ b/server/controllers/api/label.js
@@ -4,5 +4,6 @@ const router = express.Router();
 const labelService = require('../../services/label');
 
 router.post('/', labelService.createLabel);
+router.delete('/:labelId', labelService.deleteLabel);
 
 module.exports = router;

--- a/server/models/label.js
+++ b/server/models/label.js
@@ -28,7 +28,17 @@ const createLabel = async (labelData) => {
   }
 };
 
+const deleteLabel = async (labelId) => {
+  try {
+    const result = await label.destroy({ where: { id: labelId } });
+    return result;
+  } catch (err) {
+    throw new Error(errorMessages.label.deleteFailed);
+  }
+};
+
 module.exports = {
   findLabelAll,
   createLabel,
+  deleteLabel,
 };

--- a/server/services/errorMessages.js
+++ b/server/services/errorMessages.js
@@ -17,6 +17,7 @@ const errorMessages = {
     invalid: 'INVALID ERROR : the received data is invalid',
     alreadyExist: 'This label title is already exist!',
     notFoundError: 'NOT FOUND : The data is not found',
+    deleteFailed: 'DELETE ERROR : The error is occurred on deleting',
   },
   milestone: {
     invalid: 'INVALID ERROR : the received data is invalid',

--- a/server/services/label.js
+++ b/server/services/label.js
@@ -26,6 +26,18 @@ const createLabel = async (req, res) => {
   }
 };
 
+const deleteLabel = async (req, res) => {
+  try {
+    const { labelId } = req.params;
+    const isDeleted = await labelModel.deleteLabel(labelId);
+    if (isDeleted) return res.status(200).json({ message: successMessages.label.delete });
+    return res.status(404).json({ message: errorMessages.label.notFoundError });
+  } catch (err) {
+    return res.status(500).json({ message: errorMessages.server });
+  }
+};
+
 module.exports = {
   createLabel,
+  deleteLabel,
 };

--- a/server/services/successMessages.js
+++ b/server/services/successMessages.js
@@ -11,6 +11,7 @@ const successMessages = {
   label: {
     read: 'Success to find label!',
     create: 'SUCCESS : The label data is successfully created',
+    delete: 'SUCCESS : The label data is successfully deleted',
   },
   milestone: {
     create: 'SUCCESS : The milestone is successfully created',


### PR DESCRIPTION
## 설명
> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 레이블 삭제 API를 구현하기 위해 아이디로 서치하여 데이터를 destory하는 모델함수 구현
- /api/label/:labelId로 요청이 올 때 해당 서비스로 라우팅하는 컨트롤러 추가

## 체크리스트
> PR 작성자와 확인하는 리뷰어가 확인해야 할 체크리스트를 작성합니다.

- [ ] delete 요청을 보내면 정상적으로 삭제된다
- [ ] 존재하지 않는 데이터를 삭제하고자 할 때는 404 리턴

## 참고자료
> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타
> 리뷰어에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)