### PR TITLE
[Feat/update detail#93] 이슈 디테일 관계 갱신 api 구현

### DIFF
--- a/server/controllers/api/issue.js
+++ b/server/controllers/api/issue.js
@@ -10,6 +10,7 @@ router.get('/:issueId', issueService.readIssueById);
 router.put('/state', issueService.toggleState);
 router.put('/:issueId', issueService.updateIssueTitle);
 router.delete('/:issueId', issueService.deleteIssue);
+router.post('/:issueId/details', issueService.updateIssueDetail);
 
 router.get('/:issueId/comment', commentService.readCommentAll);
 router.post('/:issueId/comment', commentService.createComment);

--- a/server/models/issue.js
+++ b/server/models/issue.js
@@ -106,7 +106,7 @@ const findIssueById = async (id) => {
       where: { id },
     });
 
-    if (issueInfo) return issueInfo.get({ plain: true });
+    if (issueInfo) return issueInfo;
     return false;
   } catch (err) {
     throw new Error(ERROR_MSG.notFound);
@@ -234,6 +234,50 @@ const updateStateOfIssues = async (stateData) => {
   }
 };
 
+const addMilestoneOfIssue = async (idData) => {
+  try {
+    const { issueId, milestoneId } = idData;
+    const result = await issue.update({ milestoneId }, { where: { id: issueId } });
+    if (result) return true;
+    return false;
+  } catch (err) {
+    throw new Error(ERROR_MSG.update);
+  }
+};
+
+const deleteMilestoneOfIssue = async (issueId) => {
+  try {
+    const result = await issue.update({ milestoneId: null }, { where: { id: issueId } });
+    if (result) return true;
+    return false;
+  } catch (err) {
+    throw new Error(ERROR_MSG.update);
+  }
+};
+
+const updateDetailOfIssue = async (detailData) => {
+  try {
+    const { type, method, data, issueId } = detailData;
+    const issueInfo = await findIssueById(issueId);
+    if (!issueInfo) return false;
+    switch (type) {
+      case 'assignee':
+        if (method) return await issueInfo.addAssignee(data);
+        return await issueInfo.removeAssignee(data);
+      case 'label':
+        if (method) return await issueInfo.addLabel(data);
+        return await issueInfo.removeLabel(data);
+      case 'milestone':
+        if (method) return await addMilestoneOfIssue({ issueId, milestoneId: data });
+        return await deleteMilestoneOfIssue(issueId);
+      default:
+        return false;
+    }
+  } catch (err) {
+    throw new Error(ERROR_MSG.update);
+  }
+};
+
 module.exports = {
   createIssue,
   deleteIssue,
@@ -245,4 +289,5 @@ module.exports = {
   compareAuthor,
   updateIssueTitle,
   updateStateOfIssues,
+  updateDetailOfIssue,
 };

--- a/server/services/issue.js
+++ b/server/services/issue.js
@@ -72,7 +72,7 @@ const readIssueById = async (req, res) => {
     }
 
     const commentCount = await commentModel.commentCountById(issueId);
-    issueInfo.commentCount = commentCount;
+    issueInfo.dataValues.commentCount = commentCount;
     return res.status(200).json({ message: SUCCESS_MSG.read, data: issueInfo });
   } catch (err) {
     return res.status(500).json({ message: ERROR_MSG.server });

--- a/server/services/issue.js
+++ b/server/services/issue.js
@@ -18,6 +18,13 @@ const checkValidation = {
     if (title) return false;
     return true;
   },
+  updateDetail: (detailData) => {
+    const { type, method, data } = detailData;
+    if (!type || !data) return false;
+    if (method !== 0 && method !== 1) return false;
+    if (typeof data !== 'number') return false;
+    return true;
+  },
   toggle: (stateData) => {
     const { state, issueIds } = stateData;
     if (state !== 0 && state !== 1) return false;
@@ -127,6 +134,21 @@ const toggleState = async (req, res) => {
   }
 };
 
+const updateIssueDetail = async (req, res) => {
+  try {
+    const detailData = req.body;
+    const { issueId } = req.params;
+    if (!checkValidation.updateDetail(detailData)) {
+      return res.status(400).json({ message: ERROR_MSG.invalid });
+    }
+    const result = await issueModel.updateDetailOfIssue({ ...detailData, issueId });
+    if (result) return res.status(200).json({ message: SUCCESS_MSG.update });
+    return res.status(404).json({ message: ERROR_MSG.notFound });
+  } catch (err) {
+    return res.status(500).json({ message: ERROR_MSG.server });
+  }
+};
+
 module.exports = {
   createIssue,
   readIssueAll,
@@ -134,4 +156,5 @@ module.exports = {
   updateIssueTitle,
   toggleState,
   deleteIssue,
+  updateIssueDetail,
 };

--- a/server/test/issue.update.detail.spec.js
+++ b/server/test/issue.update.detail.spec.js
@@ -1,0 +1,320 @@
+const request = require('supertest');
+const app = require('../app');
+
+describe('POST /api/issue/{issudId}/details API는', () => {
+  it('토큰이 없을 때 401을 리턴한다.', (done) => {
+    request(app)
+      .post('/api/issue/1/details')
+      .set({
+        'Content-Type': 'application/json',
+      })
+      .send({
+        title: 'update issue example 1',
+      })
+      .expect(401)
+      .end((err, result) => {
+        if (err) {
+          done(err);
+        } else {
+          done();
+          console.log(result.body);
+        }
+      });
+  });
+  it('request body에 type 값이 없으면 400을 리턴한다.', (done) => {
+    request(app)
+      .post('/api/issue/1/details')
+      .set({
+        Authorization: process.env.TEST_TOKEN,
+        'Content-Type': 'application/json',
+      })
+      .send({
+        method: 1,
+        data: [1, 2],
+      })
+      .expect('Content-Type', /json/)
+      .expect(400)
+      .end((err, result) => {
+        if (err) {
+          done(err);
+        } else {
+          done();
+          console.log(result.body);
+        }
+      });
+  });
+  it('request body에 method 값이 없으면 400을 리턴한다.', (done) => {
+    request(app)
+      .post('/api/issue/1/details')
+      .set({
+        Authorization: process.env.TEST_TOKEN,
+        'Content-Type': 'application/json',
+      })
+      .send({
+        type: 'assignee',
+        data: [1, 2],
+      })
+      .expect('Content-Type', /json/)
+      .expect(400)
+      .end((err, result) => {
+        if (err) {
+          done(err);
+        } else {
+          done();
+          console.log(result.body);
+        }
+      });
+  });
+  it('request body에 method 값이 0이나 1이 아니면 400을 리턴한다.', (done) => {
+    request(app)
+      .post('/api/issue/1/details')
+      .set({
+        Authorization: process.env.TEST_TOKEN,
+        'Content-Type': 'application/json',
+      })
+      .send({
+        type: 'assignee',
+        method: 3,
+        data: [1, 2],
+      })
+      .expect('Content-Type', /json/)
+      .expect(400)
+      .end((err, result) => {
+        if (err) {
+          done(err);
+        } else {
+          done();
+          console.log(result.body);
+        }
+      });
+  });
+  it('request body에 data 값이 없으면 400을 리턴한다.', (done) => {
+    request(app)
+      .post('/api/issue/1/details')
+      .set({
+        Authorization: process.env.TEST_TOKEN,
+        'Content-Type': 'application/json',
+      })
+      .send({
+        type: 'assignee',
+        method: 1,
+      })
+      .expect('Content-Type', /json/)
+      .expect(400)
+      .end((err, result) => {
+        if (err) {
+          done(err);
+        } else {
+          done();
+          console.log(result.body);
+        }
+      });
+  });
+  it('request body에 data 값이 숫자가 아니면 400을 리턴한다.', (done) => {
+    request(app)
+      .post('/api/issue/1/details')
+      .set({
+        Authorization: process.env.TEST_TOKEN,
+        'Content-Type': 'application/json',
+      })
+      .send({
+        type: 'assignee',
+        method: 1,
+        data: 'not number',
+      })
+      .expect('Content-Type', /json/)
+      .expect(400)
+      .end((err, result) => {
+        if (err) {
+          done(err);
+        } else {
+          done();
+          console.log(result.body);
+        }
+      });
+  });
+  it('수정하려는 이슈가 없을 경우 404를 리턴한다.', (done) => {
+    request(app)
+      .post('/api/issue/1000/details')
+      .set({
+        Authorization: process.env.TEST_TOKEN,
+        'Content-Type': 'application/json',
+      })
+      .send({
+        type: 'assignee',
+        method: 1,
+        data: 1,
+      })
+      .expect('Content-Type', /json/)
+      .expect(404)
+      .end((err, result) => {
+        if (err) {
+          done(err);
+        } else {
+          done();
+          console.log(result.body);
+        }
+      });
+  });
+  it('type이 assignee | label | milestone이 아닐 경우 404를 리턴한다.', (done) => {
+    request(app)
+      .post('/api/issue/1000/details')
+      .set({
+        Authorization: process.env.TEST_TOKEN,
+        'Content-Type': 'application/json',
+      })
+      .send({
+        type: 'assignee',
+        method: 1,
+        data: 1,
+      })
+      .expect('Content-Type', /json/)
+      .expect(404)
+      .end((err, result) => {
+        if (err) {
+          done(err);
+        } else {
+          done();
+          console.log(result.body);
+        }
+      });
+  });
+  it('존재하지 않는 assignee를 추가할 경우, 500을 리턴한다.(assignee 변경)', (done) => {
+    request(app)
+      .post('/api/issue/2/details')
+      .set({
+        Authorization: process.env.TEST_TOKEN,
+        'Content-Type': 'application/json',
+      })
+      .send({
+        type: 'assignee',
+        method: 1,
+        data: 1000,
+      })
+      .expect('Content-Type', /json/)
+      .expect(500)
+      .end((err, result) => {
+        if (err) {
+          done(err);
+        } else {
+          done();
+          console.log(result.body);
+        }
+      });
+  });
+  it('존재하지 않는 label을 추가할 경우, 500을 리턴한다.(label 변경)', (done) => {
+    request(app)
+      .post('/api/issue/3/details')
+      .set({
+        Authorization: process.env.TEST_TOKEN,
+        'Content-Type': 'application/json',
+      })
+      .send({
+        type: 'label',
+        method: 1,
+        data: 1000,
+      })
+      .expect('Content-Type', /json/)
+      .expect(500)
+      .end((err, result) => {
+        if (err) {
+          done(err);
+        } else {
+          done();
+          console.log(result.body);
+        }
+      });
+  });
+  it('존재하지 않는 milestone을 추가할 경우, 500를 리턴한다.(milestone 변경)', (done) => {
+    request(app)
+      .post('/api/issue/4/details')
+      .set({
+        Authorization: process.env.TEST_TOKEN,
+        'Content-Type': 'application/json',
+      })
+      .send({
+        type: 'milestone',
+        method: 1,
+        data: 1000,
+      })
+      .expect('Content-Type', /json/)
+      .expect(500)
+      .end((err, result) => {
+        if (err) {
+          done(err);
+        } else {
+          done();
+          console.log(result.body);
+        }
+      });
+  });
+  it('정상적일 경우에는 200 코드와 json을 리턴한다.(assignee 변경)', (done) => {
+    request(app)
+      .post('/api/issue/2/details')
+      .set({
+        Authorization: process.env.TEST_TOKEN,
+        'Content-Type': 'application/json',
+      })
+      .send({
+        type: 'assignee',
+        method: 1,
+        data: 1,
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .end((err, result) => {
+        if (err) {
+          done(err);
+        } else {
+          done();
+          console.log(result.body);
+        }
+      });
+  });
+  it('정상적일 경우에는 200 코드와 json을 리턴한다.(label 변경)', (done) => {
+    request(app)
+      .post('/api/issue/3/details')
+      .set({
+        Authorization: process.env.TEST_TOKEN,
+        'Content-Type': 'application/json',
+      })
+      .send({
+        type: 'label',
+        method: 1,
+        data: 1,
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .end((err, result) => {
+        if (err) {
+          done(err);
+        } else {
+          done();
+          console.log(result.body);
+        }
+      });
+  });
+  it('정상적일 경우에는 200 코드와 json을 리턴한다.(milestone 변경)', (done) => {
+    request(app)
+      .post('/api/issue/4/details')
+      .set({
+        Authorization: process.env.TEST_TOKEN,
+        'Content-Type': 'application/json',
+      })
+      .send({
+        type: 'milestone',
+        method: 1,
+        data: 1,
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .end((err, result) => {
+        if (err) {
+          done(err);
+        } else {
+          done();
+          console.log(result.body);
+        }
+      });
+  });
+});


### PR DESCRIPTION
## 설명
> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.
* issue의 담당자, 라벨, 마일스톤을 갱신하는 api 구현
```
POST /api/issue/{issueId}/details
```
* 이슈 디테일을 갱신하는 api를 추가함에 따라 이슈 상세 조회시 코멘트 개수가 응답 정보로 반환되지 않는 오류 수정

## 체크리스트
> PR 작성자와 확인하는 리뷰어가 확인해야 할 체크리스트를 작성합니다.

- [ ] api 명세서대로 응답상태에 따라 알맞는 메세지를 응답받는지 확인 부탁드립니다.
    - [ ] 정상 변경시, 200 반환
    - [ ] request body에 type, method, data가 없으면 400 반환
    - [ ] 수정하려는 data가 없으면 404반환
- [ ] `GET /api/issue/{issueId}` 요청 시, 코멘트 개수도 반환되는지 확인 부탁드립니다.

## 참고자료
> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타
> 리뷰어에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)