### PR TITLE
[Feat/select detail#156] 이슈 생성 시, 담당자, 라벨, 마일스톤 저장 기능 구현

### DIFF
--- a/client/src/Components/Issue/CheckedList.js
+++ b/client/src/Components/Issue/CheckedList.js
@@ -28,7 +28,7 @@ const Label = styled.div`
   width: 100%;
   padding: 5px 10px;
   border-radius: ${(props) => props.theme.radiusSmall};
-  background-color: ${(props) => props.theme.redColor};
+  background-color: ${(props) => props.color};
   color: ${(props) => props.theme.whiteColor};
   font-weight: 600;
 `;
@@ -80,11 +80,15 @@ export const checkedLabels = () => {
   if (labels.length === 0) {
     return <Wrapper>None yet</Wrapper>;
   }
-  return (
-    <Wrapper>
-      <Label>Label</Label>
-    </Wrapper>
-  );
+  return labels.map((label) => {
+    const { id, title, color } = label;
+
+    return (
+      <Wrapper key={id}>
+        <Label color={color}>{title}</Label>
+      </Wrapper>
+    );
+  });
 };
 
 export const checkedMilestone = () => {
@@ -99,7 +103,7 @@ export const checkedMilestone = () => {
         <MilestoneTotal d="M5 10 295 10" />
         <MilestoneDone d="M5 10 100 10" />
       </MilestoneGraph>
-      <MilestoneTitle>Milestone</MilestoneTitle>
+      <MilestoneTitle>{milestone.title}</MilestoneTitle>
     </Wrapper>
   );
 };

--- a/client/src/Components/Issue/IssueSideBar.js
+++ b/client/src/Components/Issue/IssueSideBar.js
@@ -13,9 +13,9 @@ const Wrapper = styled.div`
 const NewIssue = () => {
   return (
     <Wrapper>
-      <SideBarElement title="Assignees" />
-      <SideBarElement title="Labels" />
-      <SideBarElement title="Milestone" />
+      <SideBarElement type="assignees" />
+      <SideBarElement type="labels" />
+      <SideBarElement type="milestone" />
     </Wrapper>
   );
 };

--- a/client/src/Components/Issue/NewIssueInput.js
+++ b/client/src/Components/Issue/NewIssueInput.js
@@ -4,6 +4,7 @@ import Input from '../Common/Input';
 import GreenButton from '../Common/GreenButton';
 import { request } from '../../Api';
 import { AuthStateContext } from '../../Context/AuthContext';
+import { IssueInfoContext } from '../../Context/IssueInfoContext';
 
 const Wrapper = styled.div`
   display: flex;
@@ -58,6 +59,7 @@ const LinkToMain = styled.a`
 
 const NewIssue = () => {
   const state = useContext(AuthStateContext);
+  const issueInfoState = useContext(IssueInfoContext);
   const { token } = state;
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
@@ -75,10 +77,13 @@ const NewIssue = () => {
   };
 
   const submitNewIssue = async () => {
+    const { assignees, labels, milestone } = issueInfoState;
     const data = {
       title,
       content,
-      // TODO: Assignees, labels, milestone 정보도 추가할 것
+      assignees: assignees.map((ele) => ele.id),
+      labels: labels.map((ele) => ele.id),
+      milestoneId: milestone.id,
     };
 
     const config = { url: '/api/issue', method: 'POST', data, token };

--- a/client/src/Components/Issue/SideBarElement.js
+++ b/client/src/Components/Issue/SideBarElement.js
@@ -10,16 +10,19 @@ const modalType = {
     title: `Assign up to people to this issue`,
     render: renderUsers,
     content: checkedUsers,
+    type: 'SELECT_ASSIGNEES',
   },
   Labels: {
     title: 'Apply Labels to this issue',
     render: renderLabels,
     content: checkedLabels,
+    type: 'SELECT_LABELS',
   },
   Milestone: {
     title: 'Set milestone',
     render: renderMilestones,
     content: checkedMilestone,
+    type: 'SELECT_MILESTONE',
   },
 };
 
@@ -72,7 +75,9 @@ const SideBarElement = ({ title }) => {
         <Title>{title}</Title>
         <GearIcon size="20" />
       </HeaderWrapper>
-      {modalDisplay && <SideBarModal title={modalInfo.title} render={modalInfo.render} />}
+      {modalDisplay && (
+        <SideBarModal title={modalInfo.title} render={modalInfo.render} type={modalInfo.type} />
+      )}
       <Content>{modalInfo.content()}</Content>
     </Container>
   );

--- a/client/src/Components/Issue/SideBarElement.js
+++ b/client/src/Components/Issue/SideBarElement.js
@@ -6,19 +6,22 @@ import { renderUsers, renderMilestones, renderLabels } from './SideBarList';
 import { checkedUsers, checkedLabels, checkedMilestone } from './CheckedList';
 
 const modalType = {
-  Assignees: {
+  assignees: {
+    menuTitle: 'Assignees',
     title: `Assign up to people to this issue`,
     render: renderUsers,
     content: checkedUsers,
     type: 'SELECT_ASSIGNEES',
   },
-  Labels: {
+  labels: {
+    menuTitle: 'Labels',
     title: 'Apply Labels to this issue',
     render: renderLabels,
     content: checkedLabels,
     type: 'SELECT_LABELS',
   },
-  Milestone: {
+  milestone: {
+    menuTitle: 'Milestone',
     title: 'Set milestone',
     render: renderMilestones,
     content: checkedMilestone,
@@ -61,9 +64,9 @@ const Content = styled.ul`
   color: ${(props) => props.theme.darkgrayColor};
 `;
 
-const SideBarElement = ({ title }) => {
+const SideBarElement = ({ type }) => {
   const [modalDisplay, setModalDisplay] = useState(false);
-  const [modalInfo] = useState(modalType[title]);
+  const [modalInfo] = useState(modalType[type]);
   const toggleModal = () => {
     // TODO: 전체 화면 클릭시, 모달이 띄워져 있으면 닫히도록 이벤트 수정
     setModalDisplay(!modalDisplay);
@@ -72,11 +75,16 @@ const SideBarElement = ({ title }) => {
   return (
     <Container>
       <HeaderWrapper onClick={toggleModal}>
-        <Title>{title}</Title>
+        <Title>{modalInfo.menuTitle}</Title>
         <GearIcon size="20" />
       </HeaderWrapper>
       {modalDisplay && (
-        <SideBarModal title={modalInfo.title} render={modalInfo.render} type={modalInfo.type} />
+        <SideBarModal
+          modalType={type}
+          title={modalInfo.title}
+          render={modalInfo.render}
+          type={modalInfo.type}
+        />
       )}
       <Content>{modalInfo.content()}</Content>
     </Container>

--- a/client/src/Components/Issue/SideBarList.js
+++ b/client/src/Components/Issue/SideBarList.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
 import { IssueStateContext } from '../../Context/IssueContext';
 
@@ -53,12 +53,17 @@ const MilestoneDueDate = styled.div`
   margin-top: 5px;
 `;
 
-export const renderUsers = () => {
+export const renderUsers = ({ selectedList, setSelecteList }) => {
   const { assignees } = useContext(IssueStateContext);
+  const onClickAssignee = ({ id, username, avatar }) => {
+    const data = { id, username, avatar };
+    setSelecteList([...selectedList, data]);
+  };
+
   return assignees.map((user) => {
     const { id, username, avatar } = user;
     return (
-      <ModalRow key={id}>
+      <ModalRow key={id} onClick={() => onClickAssignee(user)}>
         <Wrapper>
           <UserAvater src={avatar} alt={`${username} profile`} />
           {username}
@@ -68,10 +73,14 @@ export const renderUsers = () => {
   });
 };
 
-export const renderLabels = () => {
+export const renderLabels = ({ selectedList, setSelecteList }) => {
   const { labels } = useContext(IssueStateContext);
+  const onClickLabel = ({ id, color, title }) => {
+    const data = { id, color, title };
+    setSelecteList([...selectedList, data]);
+  };
   return labels.map((label) => (
-    <ModalRow key={label.id}>
+    <ModalRow key={label.id} onClick={() => onClickLabel(label)}>
       <Wrapper>
         <LabelImage labelColor={label.color} />
         <LabelTitle>{label.title}</LabelTitle>
@@ -81,10 +90,14 @@ export const renderLabels = () => {
   ));
 };
 
-export const renderMilestones = () => {
+export const renderMilestones = ({ setSelecteList }) => {
   const { milestones } = useContext(IssueStateContext);
+  const onClickMilestone = ({ id, title }) => {
+    const data = { id, title };
+    setSelecteList(data);
+  };
   return milestones.map((milestone) => (
-    <ModalRow key={milestone.id}>
+    <ModalRow key={milestone.id} onClick={() => onClickMilestone(milestone)}>
       <MilestoneTitle>{milestone.title}</MilestoneTitle>
       <MilestoneDueDate>{milestone.date || 'No due date'}</MilestoneDueDate>
     </ModalRow>

--- a/client/src/Components/Issue/SideBarModal.js
+++ b/client/src/Components/Issue/SideBarModal.js
@@ -1,5 +1,6 @@
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
+import { IssueInfoDispatchContext } from '../../Context/IssueInfoContext';
 
 const ModalWrapper = styled.div`
   position: absolute;
@@ -29,17 +30,18 @@ const ModalContent = styled.ul`
   cursor: pointer;
 `;
 
-const IssueFilterModal = ({ title, render }) => {
+const IssueFilterModal = ({ title, render, type }) => {
+  const [selectedList, setSelecteList] = useState([]);
+  const dispatch = useContext(IssueInfoDispatchContext);
+  // TODO: 랜더링 관해서 좀 더 고민해보기
   useEffect(() => {
-    return () => {
-      // TODO: 선택된 요소를 SideBarElement 컴포넌트의 content 컴포넌트에 추가
-    };
-  }, []);
+    return () => dispatch({ type, data: selectedList });
+  }, [selectedList]);
 
   return (
     <ModalWrapper>
       <ModalTitle>{title}</ModalTitle>
-      <ModalContent>{render()}</ModalContent>
+      <ModalContent>{render({ selectedList, setSelecteList })}</ModalContent>
     </ModalWrapper>
   );
 };

--- a/client/src/Components/Issue/SideBarModal.js
+++ b/client/src/Components/Issue/SideBarModal.js
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { IssueInfoDispatchContext } from '../../Context/IssueInfoContext';
+import { IssueInfoContext, IssueInfoDispatchContext } from '../../Context/IssueInfoContext';
 
 const ModalWrapper = styled.div`
   position: absolute;
@@ -30,12 +30,16 @@ const ModalContent = styled.ul`
   cursor: pointer;
 `;
 
-const IssueFilterModal = ({ title, render, type }) => {
+const IssueFilterModal = ({ modalType, title, render, type }) => {
+  const issueInfoState = useContext(IssueInfoContext);
+  const issueInfodispatch = useContext(IssueInfoDispatchContext);
   const [selectedList, setSelecteList] = useState([]);
-  const dispatch = useContext(IssueInfoDispatchContext);
   // TODO: 랜더링 관해서 좀 더 고민해보기
   useEffect(() => {
-    return () => dispatch({ type, data: selectedList });
+    setSelecteList(issueInfoState[modalType]);
+  }, []);
+  useEffect(() => {
+    return () => issueInfodispatch({ type, data: selectedList });
   }, [selectedList]);
 
   return (


### PR DESCRIPTION
## 설명
> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 이슈 생성 시, 담당자, 라벨, 마일스톤도 함께 저장되도록 구현
- 선택된 담당자, 라벨, 마일스톤이 있을 경우, 모달을 띄웠다 닫으면 선택된 정보를 유지합니다.

- TODO: 선택된 담당자, 라벨, 마일스톤이 있을 경우, 모달을 열때, 선택된 요소는 체크표시를 추가해야함
- TODO: 모달창에서 선택되어 있는 요소를 다시 클릭할 경우, 선택 리스트에서 제거해야할 것

## 체크리스트
> PR 작성자와 확인하는 리뷰어가 확인해야 할 체크리스트를 작성합니다.

- [ ] 이슈 생성 시, 담당자, 라벨, 마일스톤도 정상 추가되는지 확인 부탁드립니다.
- [ ] 선택된 담당자, 라벨, 마일스톤이 있을 경우, 모달을 띄웠다 닫으면 선택된 정보를 유지하는지 확인 부탁드립니다.

## 참고자료
> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

![image](https://user-images.githubusercontent.com/49746644/98639244-2723d800-236d-11eb-81be-2f983d8d9fac.png)
![image](https://user-images.githubusercontent.com/49746644/98639367-2ee37c80-236d-11eb-8ba8-ebace804bb15.png)


## 기타
> 리뷰어에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)