### PR TITLE
[Feat/label click#178] 목록에 있는 레이블 클릭 시 레이블 있는 이슈만 필터링

### DIFF
--- a/client/src/Components/Issue/Issue.js
+++ b/client/src/Components/Issue/Issue.js
@@ -7,7 +7,7 @@ import LabelMilestoneButton from '../Common/LabelMilestoneButton';
 import GreenButton from '../Common/GreenButton';
 import { request } from '../../Api';
 import { AuthStateContext, AuthDispatchContext } from '../../Context/AuthContext';
-import { IssueDispatchContext } from '../../Context/IssueContext';
+import { IssueDispatchContext, IssueStateContext } from '../../Context/IssueContext';
 
 const Wrapper = styled.div`
   display: flex;
@@ -27,11 +27,16 @@ const IssueHeader = styled.div`
 const Issue = ({ token }) => {
   const authState = useContext(AuthStateContext);
   const authDispatch = useContext(AuthDispatchContext);
+  const issueState = useContext(IssueStateContext);
   const issueDispatch = useContext(IssueDispatchContext);
   const [issueHeader, setIssueHeader] = useState({});
 
   const fetchHeader = async () => {
-    const config = { url: '/api/all', method: 'GET', token: authState.token };
+    const config = {
+      url: '/api/all',
+      method: 'GET',
+      token: authState.token,
+    };
     const { data } = await request(config);
     if (data) {
       setIssueHeader(data);
@@ -40,7 +45,12 @@ const Issue = ({ token }) => {
   };
 
   const fetchIssues = async () => {
-    const config = { url: '/api/issue', method: 'GET', token: authState.token };
+    const config = {
+      url: '/api/issue',
+      method: 'GET',
+      token: authState.token,
+      params: issueState.filter,
+    };
     const { data } = await request(config);
     if (data) issueDispatch({ type: 'FETCH_ISSUES', payload: data });
   };
@@ -57,7 +67,7 @@ const Issue = ({ token }) => {
     return () => {
       setIssueHeader([]);
     };
-  }, [authState.token]);
+  }, [authState.token, issueState.filter]);
 
   return (
     <Wrapper>

--- a/client/src/Components/Issue/IssueFilter/IssueFilterRender.js
+++ b/client/src/Components/Issue/IssueFilter/IssueFilterRender.js
@@ -116,27 +116,10 @@ export const renderMark = () => {
     return result;
   };
 
-  const fetchIssues = async () => {
-    const config = { url: '/api/issue', method: 'GET', token: authState.token };
-    const { data } = await request(config);
-    if (data) {
-      dispatch({ type: 'FETCH_ISSUES', payload: data });
-      dispatch({ type: 'UNCHECK_ALL_ISSUE' });
-    }
-  };
-
-  const fetchHeaders = async () => {
-    const config = { url: '/api/all', method: 'GET', token: authState.token };
-    const { data } = await request(config);
-    if (data) dispatch({ type: 'FETCH_HEADER', payload: data });
-  };
-
   const onClickMark = async (typeString) => {
     const result = await putState(typeString);
     if (result) {
       dispatch({ type: 'RESET_FILTER' });
-      await fetchIssues();
-      await fetchHeaders();
     }
   };
 

--- a/client/src/Components/Issue/IssueLabel.js
+++ b/client/src/Components/Issue/IssueLabel.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
+import { IssueDispatchContext } from '../../Context/IssueContext';
 
 const Badge = styled.span`
   display: inline-flex;
@@ -17,8 +18,18 @@ const Badge = styled.span`
 `;
 
 const IssueLabelBadge = (props) => {
-  const { title, color } = props;
-  return <Badge color={color}>{title}</Badge>;
+  const issueDispatch = useContext(IssueDispatchContext);
+  const { id, title, color } = props;
+
+  const onClickLabel = (labelId) => {
+    issueDispatch({ type: 'SET_ONE_LABEL', id: labelId });
+  };
+
+  return (
+    <Badge onClick={() => onClickLabel(id)} color={color}>
+      {title}
+    </Badge>
+  );
 };
 
 export default IssueLabelBadge;

--- a/client/src/Components/Issue/IssueLabel.js
+++ b/client/src/Components/Issue/IssueLabel.js
@@ -15,6 +15,7 @@ const Badge = styled.span`
   border-radius: ${(props) => props.theme.badgeRadius};
   font-weight: 600;
   font-size: 11px;
+  cursor: pointer;
 `;
 
 const IssueLabelBadge = (props) => {

--- a/client/src/Components/Issue/IssueListHeaderText.js
+++ b/client/src/Components/Issue/IssueListHeaderText.js
@@ -1,9 +1,7 @@
 import React, { useContext } from 'react';
 import styled from 'styled-components';
 import { IssueOpenIcon, CheckIcon } from '../static/svgIcons';
-import { AuthStateContext } from '../../Context/AuthContext';
 import { IssueStateContext, IssueDispatchContext } from '../../Context/IssueContext';
-import { request } from '../../Api';
 
 const HeaderTextWrapper = styled.span`
   display: inline-flex;
@@ -21,46 +19,25 @@ const CountSpanText = styled.span`
 `;
 
 const CountText = () => {
-  const authState = useContext(AuthStateContext);
   const state = useContext(IssueStateContext);
   const dispatch = useContext(IssueDispatchContext);
   const { openCount, closedCount, filter } = state;
 
-  const fetchByState = async (type) => {
-    const config = {
-      url: '/api/issue',
-      method: 'get',
-      params: {
-        ...state.filter,
-        state: type,
-      },
-      token: authState.token,
-    };
-    const { data = null } = await request(config);
-    return data;
-  };
-
-  const onClickClosed = async () => {
-    const data = await fetchByState('closed');
-    if (data) dispatch({ type: 'CLOSE', payload: data });
-  };
-
-  const onClickOpen = async () => {
-    const data = await fetchByState('open');
-    if (data) dispatch({ type: 'OPEN', payload: data });
+  const onClickMark = async (markType = 'OPEN') => {
+    dispatch({ type: markType });
   };
 
   return (
     <>
       <HeaderTextWrapper>
         <IssueOpenIcon size={14} />
-        <CountSpanText onClick={onClickOpen} bold={filter.state === 'open'}>
+        <CountSpanText onClick={() => onClickMark('OPEN')} bold={filter.state === 'open'}>
           {openCount} open
         </CountSpanText>
       </HeaderTextWrapper>
       <HeaderTextWrapper color="redColor">
         <CheckIcon size={14} />
-        <CountSpanText onClick={onClickClosed} bold={filter.state === 'closed'}>
+        <CountSpanText onClick={() => onClickMark('CLOSE')} bold={filter.state === 'closed'}>
           {closedCount} closed
         </CountSpanText>
       </HeaderTextWrapper>

--- a/client/src/Context/IssueContext.js
+++ b/client/src/Context/IssueContext.js
@@ -37,7 +37,6 @@ export const issueReducer = (state, action) => {
           ...state.filter,
           state: 'open',
         },
-        issues: [...action.payload],
       };
     }
     case 'CLOSE': {
@@ -47,7 +46,6 @@ export const issueReducer = (state, action) => {
           ...state.filter,
           state: 'closed',
         },
-        issues: [...action.payload],
       };
     }
     case 'ALL': {
@@ -57,7 +55,6 @@ export const issueReducer = (state, action) => {
           ...state.filter,
           state: 'all',
         },
-        issues: [...action.payload],
       };
     }
     case 'SET_AUTHOR': {
@@ -78,6 +75,15 @@ export const issueReducer = (state, action) => {
           author: null,
         },
         issues: [...action.payload],
+      };
+    }
+    case 'SET_ONE_LABEL': {
+      return {
+        ...state,
+        filter: {
+          ...state.filter,
+          label: [action.id],
+        },
       };
     }
     case 'SET_ASSIGNEE': {
@@ -110,6 +116,7 @@ export const issueReducer = (state, action) => {
           milestones: null,
           assignees: null,
         },
+        checkedIds: [],
       };
     }
     case 'STORE_DETAIL_DATA': {


### PR DESCRIPTION
## 설명
> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- Label 클릭에 따라 필터링 효과
- 코드 리팩토링 (중복되는 fetch 코드 줄임)

## 체크리스트
> PR 작성자와 확인하는 리뷰어가 확인해야 할 체크리스트를 작성합니다.

- [ ] Label 클릭 시 해당 레이블이 있는 이슈만 보인다.

## 참고자료
> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

#### 한 가지 버그는.. /api/all에서 레이블에 해당하는 count를 넘겨주지 않네요. 대대적 공사 필요 😂

## 기타
> 리뷰어에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
<img width="1437" alt="스크린샷 2020-11-10 오후 5 00 19" src="https://user-images.githubusercontent.com/43198553/98646097-38bdad80-2376-11eb-9d75-a092da5d8a3a.png">
