### PR TITLE
[Fix/bug#216] 이슈 생성시, comment 생성 오류 수정

### DIFF
--- a/client/src/Components/Issue/InputComment.js
+++ b/client/src/Components/Issue/InputComment.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useRef } from 'react';
 import styled from 'styled-components';
 import { AuthStateContext } from '../../Context/AuthContext';
 import { IssueInfoDispatchContext } from '../../Context/IssueInfoContext';
@@ -35,6 +35,7 @@ const InputFile = styled.input`
 const InputComment = () => {
   const authState = useContext(AuthStateContext);
   const issueInfoDispatch = useContext(IssueInfoDispatchContext);
+  const inputContent = useRef();
 
   const onChangeContent = (event) => {
     const data = event.target.value;
@@ -50,7 +51,7 @@ const InputComment = () => {
     const result = await uploadRequest(config);
     const filePath = result.data;
     const text = `![images](${filePath})\n`;
-    const inputContentElement = document.querySelector('#inputContent');
+    const inputContentElement = inputContent.current;
     const inputContentText = inputContentElement.value + text;
     issueInfoDispatch({ type: 'SET_CONTENT', data: inputContentText });
     inputContentElement.value = inputContentText;
@@ -61,7 +62,7 @@ const InputComment = () => {
     <ContentWrapper>
       <InputContent
         placeholder="Leave a comment"
-        id="inputContent"
+        ref={inputContent}
         rows="10"
         onChange={onChangeContent}
       />

--- a/client/src/Components/Issue/InputComment.js
+++ b/client/src/Components/Issue/InputComment.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
 import { AuthStateContext } from '../../Context/AuthContext';
 import { IssueInfoDispatchContext } from '../../Context/IssueInfoContext';
@@ -51,7 +51,9 @@ const InputComment = () => {
     const filePath = result.data;
     const text = `![images](${filePath})\n`;
     const inputContentElement = document.querySelector('#inputContent');
-    inputContentElement.value += text;
+    const inputContentText = inputContentElement.value + text;
+    issueInfoDispatch({ type: 'SET_CONTENT', data: inputContentText });
+    inputContentElement.value = inputContentText;
     target.value = null;
   };
 


### PR DESCRIPTION
## 설명
> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 이슈 생성 시, comment에 사진 정보만 있을 경우, comment가 null 값으로 저장되는 오류 수정

## 체크리스트
> PR 작성자와 확인하는 리뷰어가 확인해야 할 체크리스트를 작성합니다.

- [ ] comment에 사진만 추가했을 때, comment가 정상적으로 생성되는지 확인 부탁드립니다.

## 참고자료
> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타
> 리뷰어에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)